### PR TITLE
feat: add custom API base URL support for OpenAI-compatible wrappers

### DIFF
--- a/internal/ai/analysis_refiner.go
+++ b/internal/ai/analysis_refiner.go
@@ -16,10 +16,10 @@ import (
 // The refiner uses the AI supervisor to iteratively improve the analysis,
 // incorporating feedback from previous iterations to find missed work.
 type AnalysisRefiner struct {
-	supervisor *Supervisor
-	issue      *types.Issue
+	supervisor  *Supervisor
+	issue       *types.Issue
 	agentOutput string
-	success    bool
+	success     bool
 
 	// minConfidence is the minimum confidence for convergence (0.0-1.0)
 	minConfidence float64

--- a/internal/ai/analysis_refiner_test.go
+++ b/internal/ai/analysis_refiner_test.go
@@ -13,9 +13,9 @@ import (
 func TestNewAnalysisRefiner(t *testing.T) {
 	// Create test issue
 	issue := &types.Issue{
-		ID:    "test-1",
-		Title: "Test Issue",
-		Description: "Test description",
+		ID:                 "test-1",
+		Title:              "Test Issue",
+		Description:        "Test description",
 		AcceptanceCriteria: "1. Should work\n2. Should be tested",
 	}
 
@@ -81,9 +81,9 @@ func TestNewAnalysisRefiner(t *testing.T) {
 // TestSerializeAnalysis tests analysis serialization
 func TestSerializeAnalysis(t *testing.T) {
 	analysis := &Analysis{
-		Completed:  true,
-		Confidence: 0.95,
-		Summary:    "Test summary",
+		Completed:   true,
+		Confidence:  0.95,
+		Summary:     "Test summary",
 		PuntedItems: []string{"Item 1", "Item 2"},
 		DiscoveredIssues: []DiscoveredIssue{
 			{
@@ -363,9 +363,9 @@ func TestDeserializeAnalysis(t *testing.T) {
 // TestSerializeAnalysisEdgeCases tests serialization edge cases
 func TestSerializeAnalysisEdgeCases(t *testing.T) {
 	tests := []struct {
-		name     string
-		analysis *Analysis
-		expected []string
+		name        string
+		analysis    *Analysis
+		expected    []string
 		notExpected []string
 	}{
 		{

--- a/internal/ai/assessment.go
+++ b/internal/ai/assessment.go
@@ -14,18 +14,18 @@ import (
 
 // Assessment represents an AI assessment of an issue before execution
 type Assessment struct {
-	Strategy         string            `json:"strategy"`           // High-level strategy for completing the issue
-	Steps            []string          `json:"steps"`              // Specific steps to take
-	Risks            []string          `json:"risks"`              // Potential risks or challenges
-	Confidence       float64           `json:"confidence"`         // Confidence score (0.0-1.0)
-	Reasoning        string            `json:"reasoning"`          // Detailed reasoning
-	ShouldDecompose  bool              `json:"should_decompose"`   // Whether this issue should be split into child issues (vc-rzqe)
+	Strategy          string             `json:"strategy"`                     // High-level strategy for completing the issue
+	Steps             []string           `json:"steps"`                        // Specific steps to take
+	Risks             []string           `json:"risks"`                        // Potential risks or challenges
+	Confidence        float64            `json:"confidence"`                   // Confidence score (0.0-1.0)
+	Reasoning         string             `json:"reasoning"`                    // Detailed reasoning
+	ShouldDecompose   bool               `json:"should_decompose"`             // Whether this issue should be split into child issues (vc-rzqe)
 	DecompositionPlan *DecompositionPlan `json:"decomposition_plan,omitempty"` // Plan for decomposing into child issues (vc-rzqe)
 }
 
 // DecompositionPlan describes how to break an issue into child issues (vc-rzqe)
 type DecompositionPlan struct {
-	Reasoning  string      `json:"reasoning"`   // Why decomposition is recommended
+	Reasoning   string       `json:"reasoning"`    // Why decomposition is recommended
 	ChildIssues []ChildIssue `json:"child_issues"` // Proposed child issues
 }
 
@@ -137,14 +137,14 @@ func (s *Supervisor) AssessIssueStateWithRefinement(ctx context.Context, issue *
 		// Record metrics for skipped iteration (vc-642z)
 		if collector != nil {
 			metrics := &iterative.ArtifactMetrics{
-				ArtifactType:     "assessment",
-				Priority:         fmt.Sprintf("P%d", issue.Priority),
-				TotalIterations:  0,
-				Converged:        true,
+				ArtifactType:      "assessment",
+				Priority:          fmt.Sprintf("P%d", issue.Priority),
+				TotalIterations:   0,
+				Converged:         true,
 				ConvergenceReason: "selectivity skip",
-				TotalDuration:    time.Since(startTime),
-				IterationSkipped: true,
-				SkipReason:       skipReason,
+				TotalDuration:     time.Since(startTime),
+				IterationSkipped:  true,
+				SkipReason:        skipReason,
 			}
 			collector.RecordArtifactComplete(&iterative.ConvergenceResult{
 				Iterations:  0,

--- a/internal/ai/assessment_refiner_test.go
+++ b/internal/ai/assessment_refiner_test.go
@@ -67,11 +67,11 @@ func TestNewAssessmentRefiner(t *testing.T) {
 
 func TestSerializeAssessment(t *testing.T) {
 	assessment := &Assessment{
-		Strategy:   "Implement feature X",
-		Steps:      []string{"Step 1", "Step 2", "Step 3"},
-		Risks:      []string{"Risk A", "Risk B"},
-		Confidence: 0.85,
-		Reasoning:  "This is the best approach",
+		Strategy:        "Implement feature X",
+		Steps:           []string{"Step 1", "Step 2", "Step 3"},
+		Risks:           []string{"Risk A", "Risk B"},
+		Confidence:      0.85,
+		Reasoning:       "This is the best approach",
 		ShouldDecompose: false,
 	}
 
@@ -106,11 +106,11 @@ func TestSerializeAssessment(t *testing.T) {
 
 func TestSerializeAssessmentWithDecomposition(t *testing.T) {
 	assessment := &Assessment{
-		Strategy:   "Decompose into smaller tasks",
-		Steps:      []string{"Analyze", "Break down"},
-		Risks:      []string{"Complexity"},
-		Confidence: 0.70,
-		Reasoning:  "Too large for one task",
+		Strategy:        "Decompose into smaller tasks",
+		Steps:           []string{"Analyze", "Break down"},
+		Risks:           []string{"Complexity"},
+		Confidence:      0.70,
+		Reasoning:       "Too large for one task",
 		ShouldDecompose: true,
 		DecompositionPlan: &DecompositionPlan{
 			Reasoning: "Multiple independent components",
@@ -197,9 +197,9 @@ func TestShouldIterateAssessment_Mission(t *testing.T) {
 func TestShouldIterateAssessment_SimpleIssue(t *testing.T) {
 	supervisor := &Supervisor{}
 	issue := &types.Issue{
-		ID:       "vc-test",
-		Priority: 2,
-		Title:    "Simple fix",
+		ID:        "vc-test",
+		Priority:  2,
+		Title:     "Simple fix",
 		IssueType: types.TypeTask,
 	}
 
@@ -228,10 +228,10 @@ func TestBuildIterationContext(t *testing.T) {
 	}
 
 	assessment := &Assessment{
-		Strategy:   "New strategy",
-		Steps:      []string{"Step 1", "Step 2", "Step 3"},
-		Risks:      []string{"Risk A", "Risk B", "Risk C"},
-		Confidence: 0.85,
+		Strategy:        "New strategy",
+		Steps:           []string{"Step 1", "Step 2", "Step 3"},
+		Risks:           []string{"Risk A", "Risk B", "Risk C"},
+		Confidence:      0.85,
 		ShouldDecompose: false,
 	}
 
@@ -276,10 +276,10 @@ func TestBuildIterationContextEmptyRisks(t *testing.T) {
 	}
 
 	assessment := &Assessment{
-		Strategy:   "Simple strategy",
-		Steps:      []string{"Step 1"},
-		Risks:      []string{},
-		Confidence: 0.90,
+		Strategy:        "Simple strategy",
+		Steps:           []string{"Step 1"},
+		Risks:           []string{},
+		Confidence:      0.90,
 		ShouldDecompose: false,
 	}
 
@@ -414,11 +414,11 @@ func TestAssessmentRefinerRefineNilArtifact(t *testing.T) {
 // TestSerializeAssessmentMinimal tests minimal assessment serialization
 func TestSerializeAssessmentMinimal(t *testing.T) {
 	assessment := &Assessment{
-		Strategy:   "Simple strategy",
-		Steps:      []string{},
-		Risks:      []string{},
-		Confidence: 0.5,
-		Reasoning:  "Basic reasoning",
+		Strategy:        "Simple strategy",
+		Steps:           []string{},
+		Risks:           []string{},
+		Confidence:      0.5,
+		Reasoning:       "Basic reasoning",
 		ShouldDecompose: false,
 	}
 
@@ -454,18 +454,18 @@ func TestSelectivityMetrics(t *testing.T) {
 
 		// Record a skipped artifact
 		metrics := &iterative.ArtifactMetrics{
-			ArtifactType:     "assessment",
-			Priority:         "P2",
-			TotalIterations:  0,
-			Converged:        true,
+			ArtifactType:      "assessment",
+			Priority:          "P2",
+			TotalIterations:   0,
+			Converged:         true,
 			ConvergenceReason: "selectivity skip",
-			IterationSkipped: true,
-			SkipReason:       "simple issue (no complexity triggers)",
+			IterationSkipped:  true,
+			SkipReason:        "simple issue (no complexity triggers)",
 		}
 
 		collector.RecordArtifactComplete(&iterative.ConvergenceResult{
-			Iterations:  0,
-			Converged:   true,
+			Iterations: 0,
+			Converged:  true,
 		}, metrics)
 
 		agg := collector.GetAggregateMetrics()
@@ -500,8 +500,8 @@ func TestSelectivityMetrics(t *testing.T) {
 		}
 
 		collector.RecordArtifactComplete(&iterative.ConvergenceResult{
-			Iterations:  4,
-			Converged:   true,
+			Iterations: 4,
+			Converged:  true,
 		}, metrics)
 
 		agg := collector.GetAggregateMetrics()

--- a/internal/ai/baseurl_integration_test.go
+++ b/internal/ai/baseurl_integration_test.go
@@ -1,0 +1,52 @@
+package ai
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestBaseURLIntegration tests actual API connectivity with custom base URL
+// Run with: VC_API_BASE=http://localhost:8000 go test ./internal/ai/... -run TestBaseURLIntegration -v
+func TestBaseURLIntegration(t *testing.T) {
+	baseURL := os.Getenv("VC_API_BASE")
+	if baseURL == "" {
+		t.Skip("Skipping integration test: VC_API_BASE not set")
+	}
+
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		// For wrapper, we may not need a real key - use a placeholder
+		apiKey = "test-wrapper-key"
+	}
+
+	cfg := &Config{
+		APIKey:  apiKey,
+		BaseURL: baseURL,
+		Store:   newMockStorage(),
+	}
+
+	sup, err := NewSupervisor(cfg)
+	if err != nil {
+		t.Fatalf("NewSupervisor failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Make a simple API call
+	resp, err := sup.CallAPI(ctx, "Say 'hello' and nothing else.", "", 50)
+	if err != nil {
+		t.Fatalf("CallAPI failed: %v", err)
+	}
+
+	if resp == nil {
+		t.Fatal("CallAPI returned nil response")
+	}
+
+	t.Logf("API response received successfully via custom endpoint %s", baseURL)
+	if len(resp.Content) > 0 {
+		t.Logf("Response content: %+v", resp.Content[0])
+	}
+}

--- a/internal/ai/baseurl_test.go
+++ b/internal/ai/baseurl_test.go
@@ -1,0 +1,69 @@
+package ai
+
+import (
+	"os"
+	"testing"
+)
+
+// TestBaseURLConfiguration verifies that the BaseURL configuration works correctly
+func TestBaseURLConfiguration(t *testing.T) {
+	t.Run("config BaseURL takes precedence over env var", func(t *testing.T) {
+		// Set env var
+		os.Setenv("VC_API_BASE", "http://env-url:8000")
+		defer os.Unsetenv("VC_API_BASE")
+
+		// Config with explicit BaseURL should use that
+		cfg := &Config{
+			APIKey:  "test-key",
+			BaseURL: "http://config-url:9000",
+			Store:   newMockStorage(),
+		}
+
+		// NewSupervisor will use cfg.BaseURL, not env var
+		// We can't easily test the client was configured correctly without
+		// making a real API call, but we can verify the config is accepted
+		sup, err := NewSupervisor(cfg)
+		if err != nil {
+			t.Fatalf("NewSupervisor failed: %v", err)
+		}
+		if sup == nil {
+			t.Fatal("NewSupervisor returned nil")
+		}
+	})
+
+	t.Run("env var used when config BaseURL empty", func(t *testing.T) {
+		os.Setenv("VC_API_BASE", "http://localhost:8000")
+		defer os.Unsetenv("VC_API_BASE")
+
+		cfg := &Config{
+			APIKey: "test-key",
+			Store:  newMockStorage(),
+			// BaseURL intentionally empty
+		}
+
+		sup, err := NewSupervisor(cfg)
+		if err != nil {
+			t.Fatalf("NewSupervisor failed: %v", err)
+		}
+		if sup == nil {
+			t.Fatal("NewSupervisor returned nil")
+		}
+	})
+
+	t.Run("no BaseURL uses default Anthropic endpoint", func(t *testing.T) {
+		os.Unsetenv("VC_API_BASE")
+
+		cfg := &Config{
+			APIKey: "test-key",
+			Store:  newMockStorage(),
+		}
+
+		sup, err := NewSupervisor(cfg)
+		if err != nil {
+			t.Fatalf("NewSupervisor failed: %v", err)
+		}
+		if sup == nil {
+			t.Fatal("NewSupervisor returned nil")
+		}
+	})
+}

--- a/internal/ai/decomposition_test.go
+++ b/internal/ai/decomposition_test.go
@@ -9,14 +9,14 @@ import (
 
 // mockStore implements IssueStore interface for testing
 type mockStore struct {
-	createdIssues    []*types.Issue
-	dependencies     []*types.Dependency
-	labels           map[string][]string // issueID -> labels
-	updates          map[string]map[string]interface{} // issueID -> updates
-	createError      error
-	dependencyError  error
-	labelError       error
-	updateError      error
+	createdIssues   []*types.Issue
+	dependencies    []*types.Dependency
+	labels          map[string][]string               // issueID -> labels
+	updates         map[string]map[string]interface{} // issueID -> updates
+	createError     error
+	dependencyError error
+	labelError      error
+	updateError     error
 }
 
 func newMockStore() *mockStore {
@@ -66,10 +66,10 @@ func TestDecomposeIssue(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name          string
-		parentIssue   *types.Issue
-		plan          *DecompositionPlan
-		wantErr       bool
+		name           string
+		parentIssue    *types.Issue
+		plan           *DecompositionPlan
+		wantErr        bool
 		wantChildCount int
 	}{
 		{
@@ -97,7 +97,7 @@ func TestDecomposeIssue(t *testing.T) {
 					},
 				},
 			},
-			wantErr:       false,
+			wantErr:        false,
 			wantChildCount: 2,
 		},
 		{
@@ -106,8 +106,8 @@ func TestDecomposeIssue(t *testing.T) {
 				ID:    "test-parent",
 				Title: "Parent issue",
 			},
-			plan:          nil,
-			wantErr:       true,
+			plan:           nil,
+			wantErr:        true,
 			wantChildCount: 0,
 		},
 		{
@@ -120,7 +120,7 @@ func TestDecomposeIssue(t *testing.T) {
 				Reasoning:   "Empty",
 				ChildIssues: []ChildIssue{},
 			},
-			wantErr:       true,
+			wantErr:        true,
 			wantChildCount: 0,
 		},
 	}

--- a/internal/ai/description_parsing_test.go
+++ b/internal/ai/description_parsing_test.go
@@ -33,13 +33,13 @@ func TestParseDescription(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                string
-		description         string
-		expectGoal          bool
-		expectConstraints   bool
-		minConstraints      int
-		maxConstraints      int
-		shouldContain       []string // Keywords that should appear in goal or constraints
+		name              string
+		description       string
+		expectGoal        bool
+		expectConstraints bool
+		minConstraints    int
+		maxConstraints    int
+		shouldContain     []string // Keywords that should appear in goal or constraints
 	}{
 		{
 			name:              "simple goal without constraints",

--- a/internal/ai/health_check_test.go
+++ b/internal/ai/health_check_test.go
@@ -28,7 +28,7 @@ func TestSupervisorHealthCheck(t *testing.T) {
 		// Open the circuit
 		s.circuitBreaker.RecordFailure()
 		s.circuitBreaker.RecordFailure()
-		
+
 		// Transition to half-open by simulating timeout
 		s.circuitBreaker.mu.Lock()
 		s.circuitBreaker.transitionToHalfOpen()

--- a/internal/ai/json_parser_test.go
+++ b/internal/ai/json_parser_test.go
@@ -80,15 +80,15 @@ func TestParse_WithCodeFences(t *testing.T) {
 				"```",
 		},
 		{
-			name: "json fence without newlines (vc-226 edge case)",
+			name:  "json fence without newlines (vc-226 edge case)",
 			input: "```json" + `{"success": true, "message": "no newlines"}` + "```",
 		},
 		{
-			name: "json fence with space but no newline",
+			name:  "json fence with space but no newline",
 			input: "```json " + `{"success": true, "message": "space no newline"}` + "```",
 		},
 		{
-			name: "fence without language or newlines",
+			name:  "fence without language or newlines",
 			input: "```" + `{"success": true, "message": "minimal"}` + "```",
 		},
 	}
@@ -497,8 +497,8 @@ func TestRemoveCodeFences(t *testing.T) {
 
 func TestCleanupJSON(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
+		name        string
+		input       string
 		shouldParse bool
 	}{
 		{

--- a/internal/ai/meta_issue_workflow_test.go
+++ b/internal/ai/meta_issue_workflow_test.go
@@ -54,13 +54,13 @@ func TestMetaIssueWorkflowIntegration(t *testing.T) {
 		// The AI would detect: "This issue has no clear completion criteria"
 		discoveredIssues := []DiscoveredIssue{
 			{
-				Title:       "Add acceptance criteria to " + parentIssue.ID,
-				Description: "Issue " + parentIssue.ID + " lacks specific acceptance criteria. Without clear criteria, it's impossible to determine when the work is complete.",
-				Type:        "task",
-				Priority:    "P1", // AI suggests P1, but will be calculated based on discovery_type
-				DiscoveryType: "blocker", // This blocks the parent from being properly executed
+				Title:              "Add acceptance criteria to " + parentIssue.ID,
+				Description:        "Issue " + parentIssue.ID + " lacks specific acceptance criteria. Without clear criteria, it's impossible to determine when the work is complete.",
+				Type:               "task",
+				Priority:           "P1",      // AI suggests P1, but will be calculated based on discovery_type
+				DiscoveryType:      "blocker", // This blocks the parent from being properly executed
 				AcceptanceCriteria: "1. Add specific, measurable acceptance criteria to " + parentIssue.ID + "\n2. Ensure each criterion is testable\n3. Verify criteria cover all aspects of the feature",
-				Labels: []string{"meta-issue"}, // AI marks this as a meta-issue
+				Labels:             []string{"meta-issue"}, // AI marks this as a meta-issue
 			},
 		}
 

--- a/internal/ai/plan_refiner.go
+++ b/internal/ai/plan_refiner.go
@@ -15,19 +15,19 @@ import (
 // allowing plans to be refined through multiple AI iterations until they
 // converge to a stable, high-quality state.
 type PlanRefiner struct {
-	supervisor    *Supervisor
-	planningCtx   *types.PlanningContext
-	currentIter   int
+	supervisor  *Supervisor
+	planningCtx *types.PlanningContext
+	currentIter int
 }
 
 // PlanningCostMetrics tracks cost and performance metrics for a planning cycle
 type PlanningCostMetrics struct {
-	Iterations      int
-	TotalTokens     int
-	InputTokens     int
-	OutputTokens    int
+	Iterations       int
+	TotalTokens      int
+	InputTokens      int
+	OutputTokens     int
 	EstimatedCostUSD float64
-	TotalDuration   int64 // milliseconds
+	TotalDuration    int64 // milliseconds
 }
 
 // NewPlanRefiner creates a new plan refiner.
@@ -201,11 +201,11 @@ func (r *PlanRefiner) CheckConvergence(ctx context.Context, current, previous *i
 
 	// Parse the convergence decision
 	type convergenceResponse struct {
-		Converged     bool     `json:"converged"`
-		Confidence    float64  `json:"confidence"`
-		Reasoning     string   `json:"reasoning"`
-		DiffPercent   float64  `json:"diff_percentage"`
-		MajorChanges  []string `json:"major_changes"`
+		Converged    bool     `json:"converged"`
+		Confidence   float64  `json:"confidence"`
+		Reasoning    string   `json:"reasoning"`
+		DiffPercent  float64  `json:"diff_percentage"`
+		MajorChanges []string `json:"major_changes"`
 	}
 
 	parseResult := Parse[convergenceResponse](responseText, ParseOptions{

--- a/internal/ai/planner_test.go
+++ b/internal/ai/planner_test.go
@@ -269,14 +269,14 @@ func TestBuildPlanningPrompt(t *testing.T) {
 			CreatedAt:   now,
 			UpdatedAt:   now,
 		},
-		Goal:       "Build a working feature X",
-		Context:    "This is a critical feature",
+		Goal:    "Build a working feature X",
+		Context: "This is a critical feature",
 	}
 
 	tests := []struct {
-		name           string
-		ctx            *types.PlanningContext
-		wantInPrompt   []string
+		name            string
+		ctx             *types.PlanningContext
+		wantInPrompt    []string
 		wantNotInPrompt []string
 	}{
 		{
@@ -767,4 +767,3 @@ func TestGetEnvInt(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/ai/recovery.go
+++ b/internal/ai/recovery.go
@@ -13,14 +13,14 @@ import (
 
 // RecoveryStrategy represents AI-generated strategy for recovering from quality gate failures
 type RecoveryStrategy struct {
-	Action           string            `json:"action"`             // "fix_in_place", "acceptable_failure", "split_work", "escalate", "retry"
-	Reasoning        string            `json:"reasoning"`          // Detailed reasoning for the recommended action
-	Confidence       float64           `json:"confidence"`         // Confidence in the recommendation (0.0-1.0)
-	CreateIssues     []DiscoveredIssue `json:"create_issues"`      // Issues to create for fixes
-	MarkAsBlocked    bool              `json:"mark_as_blocked"`    // Whether to mark original issue as blocked
-	CloseOriginal    bool              `json:"close_original"`     // Whether to close the original issue (acceptable failure)
-	AddComment       string            `json:"add_comment"`        // Comment to add to original issue
-	RequiresApproval bool              `json:"requires_approval"`  // Whether human approval is needed
+	Action           string            `json:"action"`            // "fix_in_place", "acceptable_failure", "split_work", "escalate", "retry"
+	Reasoning        string            `json:"reasoning"`         // Detailed reasoning for the recommended action
+	Confidence       float64           `json:"confidence"`        // Confidence in the recommendation (0.0-1.0)
+	CreateIssues     []DiscoveredIssue `json:"create_issues"`     // Issues to create for fixes
+	MarkAsBlocked    bool              `json:"mark_as_blocked"`   // Whether to mark original issue as blocked
+	CloseOriginal    bool              `json:"close_original"`    // Whether to close the original issue (acceptable failure)
+	AddComment       string            `json:"add_comment"`       // Comment to add to original issue
+	RequiresApproval bool              `json:"requires_approval"` // Whether human approval is needed
 }
 
 // GateFailure represents a failed quality gate with details

--- a/internal/ai/retry.go
+++ b/internal/ai/retry.go
@@ -28,10 +28,10 @@ type ErrorType int
 
 const (
 	ErrorTransient ErrorType = iota // Network hiccup, server error (5xx) - retry with backoff
-	ErrorQuota                       // 429 quota/rate limit exceeded - wait for reset
-	ErrorInvalid                     // 400 bad request - don't retry
-	ErrorAuth                        // 401/403 auth error - don't retry
-	ErrorUnknown                     // Catch-all - retry with backoff
+	ErrorQuota                      // 429 quota/rate limit exceeded - wait for reset
+	ErrorInvalid                    // 400 bad request - don't retry
+	ErrorAuth                       // 401/403 auth error - don't retry
+	ErrorUnknown                    // Catch-all - retry with backoff
 )
 
 func (e ErrorType) String() string {
@@ -74,9 +74,9 @@ type RetryConfig struct {
 type CircuitState int
 
 const (
-	CircuitClosed CircuitState = iota // Normal operation, requests pass through
-	CircuitOpen                        // Too many failures, block requests (fail fast)
-	CircuitHalfOpen                    // Testing recovery, allow limited requests
+	CircuitClosed   CircuitState = iota // Normal operation, requests pass through
+	CircuitOpen                         // Too many failures, block requests (fail fast)
+	CircuitHalfOpen                     // Testing recovery, allow limited requests
 )
 
 func (s CircuitState) String() string {
@@ -140,7 +140,7 @@ func DefaultRetryConfig() RetryConfig {
 		FailureThreshold:      5,
 		SuccessThreshold:      2,
 		OpenTimeout:           30 * time.Second,
-		MaxConcurrentCalls:    3, // Limit concurrent AI calls to prevent rate limiting (vc-220)
+		MaxConcurrentCalls:    3,            // Limit concurrent AI calls to prevent rate limiting (vc-220)
 		MaxQuotaWait:          maxQuotaWait, // Maximum wait for quota reset (vc-5b22)
 	}
 }

--- a/internal/ai/retry_test.go
+++ b/internal/ai/retry_test.go
@@ -86,99 +86,99 @@ func TestParseRetryAfterFromMessage(t *testing.T) {
 // TestClassifyError tests error type classification
 func TestClassifyError(t *testing.T) {
 	tests := []struct {
-		name              string
-		err               error
-		expectedType      ErrorType
-		expectWaitTime    bool
-		minWait           time.Duration
-		maxWait           time.Duration
+		name           string
+		err            error
+		expectedType   ErrorType
+		expectWaitTime bool
+		minWait        time.Duration
+		maxWait        time.Duration
 	}{
 		{
-			name:         "nil error",
-			err:          nil,
-			expectedType: ErrorUnknown,
+			name:           "nil error",
+			err:            nil,
+			expectedType:   ErrorUnknown,
 			expectWaitTime: false,
 		},
 		{
-			name:         "generic error",
-			err:          errors.New("something went wrong"),
-			expectedType: ErrorUnknown,
+			name:           "generic error",
+			err:            errors.New("something went wrong"),
+			expectedType:   ErrorUnknown,
 			expectWaitTime: false,
 		},
 		{
-			name:         "429 rate limit in message",
-			err:          errors.New("HTTP 429: rate limit exceeded, try again in 12 minutes"),
-			expectedType: ErrorQuota,
+			name:           "429 rate limit in message",
+			err:            errors.New("HTTP 429: rate limit exceeded, try again in 12 minutes"),
+			expectedType:   ErrorQuota,
 			expectWaitTime: true,
-			minWait:      12 * time.Minute,
-			maxWait:      12 * time.Minute,
+			minWait:        12 * time.Minute,
+			maxWait:        12 * time.Minute,
 		},
 		{
-			name:         "quota in message",
-			err:          errors.New("quota exceeded, wait 720 seconds"),
-			expectedType: ErrorQuota,
+			name:           "quota in message",
+			err:            errors.New("quota exceeded, wait 720 seconds"),
+			expectedType:   ErrorQuota,
 			expectWaitTime: true,
-			minWait:      720 * time.Second,
-			maxWait:      720 * time.Second,
+			minWait:        720 * time.Second,
+			maxWait:        720 * time.Second,
 		},
 		{
-			name:         "500 internal server error",
-			err:          errors.New("HTTP 500: internal server error"),
-			expectedType: ErrorTransient,
+			name:           "500 internal server error",
+			err:            errors.New("HTTP 500: internal server error"),
+			expectedType:   ErrorTransient,
 			expectWaitTime: false,
 		},
 		{
-			name:         "502 bad gateway",
-			err:          errors.New("502 bad gateway"),
-			expectedType: ErrorTransient,
+			name:           "502 bad gateway",
+			err:            errors.New("502 bad gateway"),
+			expectedType:   ErrorTransient,
 			expectWaitTime: false,
 		},
 		{
-			name:         "503 service unavailable",
-			err:          errors.New("service unavailable (503)"),
-			expectedType: ErrorTransient,
+			name:           "503 service unavailable",
+			err:            errors.New("service unavailable (503)"),
+			expectedType:   ErrorTransient,
 			expectWaitTime: false,
 		},
 		{
-			name:         "504 gateway timeout",
-			err:          errors.New("504 gateway timeout"),
-			expectedType: ErrorTransient,
+			name:           "504 gateway timeout",
+			err:            errors.New("504 gateway timeout"),
+			expectedType:   ErrorTransient,
 			expectWaitTime: false,
 		},
 		{
-			name:         "connection refused",
-			err:          errors.New("connection refused"),
-			expectedType: ErrorTransient,
+			name:           "connection refused",
+			err:            errors.New("connection refused"),
+			expectedType:   ErrorTransient,
 			expectWaitTime: false,
 		},
 		{
-			name:         "network timeout",
-			err:          errors.New("network timeout"),
-			expectedType: ErrorTransient,
+			name:           "network timeout",
+			err:            errors.New("network timeout"),
+			expectedType:   ErrorTransient,
 			expectWaitTime: false,
 		},
 		{
-			name:         "400 bad request",
-			err:          errors.New("HTTP 400: bad request"),
-			expectedType: ErrorInvalid,
+			name:           "400 bad request",
+			err:            errors.New("HTTP 400: bad request"),
+			expectedType:   ErrorInvalid,
 			expectWaitTime: false,
 		},
 		{
-			name:         "404 not found",
-			err:          errors.New("404 not found"),
-			expectedType: ErrorInvalid,
+			name:           "404 not found",
+			err:            errors.New("404 not found"),
+			expectedType:   ErrorInvalid,
 			expectWaitTime: false,
 		},
 		{
-			name:         "401 unauthorized",
-			err:          errors.New("401 unauthorized"),
-			expectedType: ErrorAuth,
+			name:           "401 unauthorized",
+			err:            errors.New("401 unauthorized"),
+			expectedType:   ErrorAuth,
 			expectWaitTime: false,
 		},
 		{
-			name:         "403 forbidden",
-			err:          errors.New("HTTP 403: forbidden"),
-			expectedType: ErrorAuth,
+			name:           "403 forbidden",
+			err:            errors.New("HTTP 403: forbidden"),
+			expectedType:   ErrorAuth,
 			expectWaitTime: false,
 		},
 	}
@@ -206,11 +206,11 @@ func TestClassifyError(t *testing.T) {
 // TestClassifyErrorWithAnthropicSDKError tests classification with actual SDK error types
 func TestClassifyErrorWithAnthropicSDKError(t *testing.T) {
 	tests := []struct {
-		name          string
-		statusCode    int
-		retryAfter    string
-		expectedType  ErrorType
-		expectWait    bool
+		name         string
+		statusCode   int
+		retryAfter   string
+		expectedType ErrorType
+		expectWait   bool
 	}{
 		{
 			name:         "429 with Retry-After header (seconds)",
@@ -296,11 +296,11 @@ func TestClassifyErrorWithAnthropicSDKError(t *testing.T) {
 // TestParseRetryAfterWithHeaders tests parsing retry-after from HTTP headers
 func TestParseRetryAfterWithHeaders(t *testing.T) {
 	tests := []struct {
-		name         string
-		retryAfter   string
+		name           string
+		retryAfter     string
 		rateLimitReset string
-		expectedMin  time.Duration
-		expectedMax  time.Duration
+		expectedMin    time.Duration
+		expectedMax    time.Duration
 	}{
 		{
 			name:        "Retry-After in seconds",
@@ -356,38 +356,38 @@ func TestParseRetryAfterWithHeaders(t *testing.T) {
 // TestIsRetriableErrorBackwardsCompatibility tests that isRetriableError still works
 func TestIsRetriableErrorBackwardsCompatibility(t *testing.T) {
 	tests := []struct {
-		name       string
-		err        error
+		name        string
+		err         error
 		shouldRetry bool
 	}{
 		{
-			name:       "nil error",
-			err:        nil,
+			name:        "nil error",
+			err:         nil,
 			shouldRetry: false,
 		},
 		{
-			name:       "quota error - should retry",
-			err:        errors.New("429 rate limit exceeded"),
+			name:        "quota error - should retry",
+			err:         errors.New("429 rate limit exceeded"),
 			shouldRetry: true,
 		},
 		{
-			name:       "transient error - should retry",
-			err:        errors.New("500 internal server error"),
+			name:        "transient error - should retry",
+			err:         errors.New("500 internal server error"),
 			shouldRetry: true,
 		},
 		{
-			name:       "auth error - should NOT retry",
-			err:        errors.New("401 unauthorized"),
+			name:        "auth error - should NOT retry",
+			err:         errors.New("401 unauthorized"),
 			shouldRetry: false,
 		},
 		{
-			name:       "invalid request - should NOT retry",
-			err:        errors.New("400 bad request"),
+			name:        "invalid request - should NOT retry",
+			err:         errors.New("400 bad request"),
 			shouldRetry: false,
 		},
 		{
-			name:       "unknown error - should retry (conservative)",
-			err:        errors.New("mysterious error"),
+			name:        "unknown error - should retry (conservative)",
+			err:         errors.New("mysterious error"),
 			shouldRetry: true,
 		},
 	}

--- a/internal/ai/supervisor.go
+++ b/internal/ai/supervisor.go
@@ -90,12 +90,12 @@ type CostTracker interface {
 
 // Config holds supervisor configuration
 type Config struct {
-	APIKey      string          // Anthropic API key (if empty, reads from ANTHROPIC_API_KEY env var)
-	Model       string          // Model to use (default: claude-sonnet-4-5-20250929)
-	BaseURL     string          // Custom API base URL (if empty, reads from VC_API_BASE env var)
+	APIKey      string // Anthropic API key (if empty, reads from ANTHROPIC_API_KEY env var)
+	Model       string // Model to use (default: claude-sonnet-4-5-20250929)
+	BaseURL     string // Custom API base URL (if empty, reads from VC_API_BASE env var)
 	Store       storage.Storage
-	Retry       RetryConfig     // Retry configuration (uses defaults if not specified)
-	CostTracker CostTracker     // Optional cost tracker for budget enforcement (vc-e3s7)
+	Retry       RetryConfig // Retry configuration (uses defaults if not specified)
+	CostTracker CostTracker // Optional cost tracker for budget enforcement (vc-e3s7)
 }
 
 // NewSupervisor creates a new AI supervisor

--- a/internal/ai/supervisor.go
+++ b/internal/ai/supervisor.go
@@ -90,11 +90,12 @@ type CostTracker interface {
 
 // Config holds supervisor configuration
 type Config struct {
-	APIKey      string       // Anthropic API key (if empty, reads from ANTHROPIC_API_KEY env var)
-	Model       string       // Model to use (default: claude-sonnet-4-5-20250929)
+	APIKey      string          // Anthropic API key (if empty, reads from ANTHROPIC_API_KEY env var)
+	Model       string          // Model to use (default: claude-sonnet-4-5-20250929)
+	BaseURL     string          // Custom API base URL (if empty, reads from VC_API_BASE env var)
 	Store       storage.Storage
-	Retry       RetryConfig  // Retry configuration (uses defaults if not specified)
-	CostTracker CostTracker  // Optional cost tracker for budget enforcement (vc-e3s7)
+	Retry       RetryConfig     // Retry configuration (uses defaults if not specified)
+	CostTracker CostTracker     // Optional cost tracker for budget enforcement (vc-e3s7)
 }
 
 // NewSupervisor creates a new AI supervisor
@@ -122,7 +123,20 @@ func NewSupervisor(cfg *Config) (*Supervisor, error) {
 		retry = DefaultRetryConfig()
 	}
 
-	client := anthropic.NewClient(option.WithAPIKey(apiKey))
+	// Check for custom API base URL (supports OpenAI-compatible wrappers)
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = os.Getenv("VC_API_BASE")
+	}
+
+	// Build client options
+	opts := []option.RequestOption{option.WithAPIKey(apiKey)}
+	if baseURL != "" {
+		opts = append(opts, option.WithBaseURL(baseURL))
+		fmt.Printf("Using custom API base URL: %s\n", baseURL)
+	}
+
+	client := anthropic.NewClient(opts...)
 
 	// Initialize circuit breaker if enabled
 	var circuitBreaker *CircuitBreaker

--- a/internal/ai/supervisor_test.go
+++ b/internal/ai/supervisor_test.go
@@ -19,8 +19,8 @@ type mockStorage struct {
 	issues       map[string]*types.Issue
 	comments     []string
 	dependencies []types.Dependency
-	labels       map[string][]string                                                // issueID -> labels (vc-151)
-	createError  error                                                              // Inject errors for testing
+	labels       map[string][]string // issueID -> labels (vc-151)
+	createError  error               // Inject errors for testing
 	depError     error
 	createFunc   func(ctx context.Context, issue *types.Issue, actor string) error // Allow overriding
 }
@@ -517,24 +517,24 @@ func TestCreateDiscoveredIssues(t *testing.T) {
 			name: "discovery type labels (vc-151/vc-152)",
 			discovered: []DiscoveredIssue{
 				{
-					Title:        "Fix lint errors",
-					Description:  "Pre-existing lint errors block quality gates",
-					Type:         "bug",
-					Priority:     "P1", // AI suggests P1, but calculated as P0 (blocker from P2 parent)
+					Title:         "Fix lint errors",
+					Description:   "Pre-existing lint errors block quality gates",
+					Type:          "bug",
+					Priority:      "P1", // AI suggests P1, but calculated as P0 (blocker from P2 parent)
 					DiscoveryType: "blocker",
 				},
 				{
-					Title:        "Add logging",
-					Description:  "Would help debugging similar issues",
-					Type:         "task",
-					Priority:     "P2", // AI suggests P2, but calculated as P3 (related from P2 parent)
+					Title:         "Add logging",
+					Description:   "Would help debugging similar issues",
+					Type:          "task",
+					Priority:      "P2", // AI suggests P2, but calculated as P3 (related from P2 parent)
 					DiscoveryType: "related",
 				},
 				{
-					Title:        "Refactor utils",
-					Description:  "Noticed during work but unrelated",
-					Type:         "chore",
-					Priority:     "P3", // AI suggests P3, but calculated as P2 (background always P2)
+					Title:         "Refactor utils",
+					Description:   "Noticed during work but unrelated",
+					Type:          "chore",
+					Priority:      "P3", // AI suggests P3, but calculated as P2 (background always P2)
 					DiscoveryType: "background",
 				},
 			},
@@ -804,17 +804,17 @@ func generateTestOutput(length int) string {
 // issues inherit the parent's priority.
 func TestPriorityMapping(t *testing.T) {
 	tests := []struct {
-		input        string
+		input          string
 		parentPriority int
-		want         int
+		want           int
 	}{
-		{"P0", 0, 0}, // Inherits parent P0
-		{"P1", 1, 1}, // Inherits parent P1
-		{"P2", 2, 2}, // Inherits parent P2
-		{"P3", 3, 3}, // Inherits parent P3
-		{"P4", 2, 2}, // Unknown AI priority, inherits parent P2
+		{"P0", 0, 0},      // Inherits parent P0
+		{"P1", 1, 1},      // Inherits parent P1
+		{"P2", 2, 2},      // Inherits parent P2
+		{"P3", 3, 3},      // Inherits parent P3
+		{"P4", 2, 2},      // Unknown AI priority, inherits parent P2
 		{"invalid", 2, 2}, // Invalid AI priority, inherits parent P2
-		{"", 2, 2},   // Empty AI priority, inherits parent P2
+		{"", 2, 2},        // Empty AI priority, inherits parent P2
 	}
 
 	store := newMockStorage()
@@ -1179,7 +1179,8 @@ func TestCircuitBreakerWithRetry(t *testing.T) {
 	t.Run("circuit breaker blocks retries when open", func(t *testing.T) {
 		store := newMockStorage()
 		cfg := &Config{
-			Store: store,
+			APIKey: "test-key",
+			Store:  store,
 			Retry: RetryConfig{
 				MaxRetries:            3,
 				InitialBackoff:        10 * time.Millisecond,
@@ -1238,7 +1239,8 @@ func TestCircuitBreakerWithRetry(t *testing.T) {
 	t.Run("successful request records success with circuit breaker", func(t *testing.T) {
 		store := newMockStorage()
 		cfg := &Config{
-			Store: store,
+			APIKey: "test-key",
+			Store:  store,
 			Retry: RetryConfig{
 				MaxRetries:            3,
 				InitialBackoff:        10 * time.Millisecond,
@@ -1284,7 +1286,8 @@ func TestCircuitBreakerWithRetry(t *testing.T) {
 	t.Run("non-retriable errors don't affect circuit breaker", func(t *testing.T) {
 		store := newMockStorage()
 		cfg := &Config{
-			Store: store,
+			APIKey: "test-key",
+			Store:  store,
 			Retry: RetryConfig{
 				MaxRetries:            3,
 				InitialBackoff:        10 * time.Millisecond,
@@ -1364,7 +1367,8 @@ func TestCircuitBreakerStateTransitions(t *testing.T) {
 func TestCircuitBreakerDisabled(t *testing.T) {
 	store := newMockStorage()
 	cfg := &Config{
-		Store: store,
+		APIKey: "test-key",
+		Store:  store,
 		Retry: RetryConfig{
 			MaxRetries:            3,
 			InitialBackoff:        10 * time.Millisecond,

--- a/internal/ai/test_failure.go
+++ b/internal/ai/test_failure.go
@@ -150,6 +150,6 @@ RULES:
 4. For real failures, trace through the logic to find the bug
 5. Include concrete verification steps
 
-IMPORTANT: Respond with ONLY raw JSON. Do NOT wrap it in markdown code fences (` + "`" + `). Just the JSON object.`,
+IMPORTANT: Respond with ONLY raw JSON. Do NOT wrap it in markdown code fences (`+"`"+`). Just the JSON object.`,
 		issue.ID, issue.Title, issue.Description, truncateString(testOutput, 8000))
 }

--- a/internal/ai/translation.go
+++ b/internal/ai/translation.go
@@ -47,11 +47,11 @@ import (
 type DiscoveredIssue struct {
 	Title              string   `json:"title"`
 	Description        string   `json:"description"`
-	Type               string   `json:"type"`               // bug, task, enhancement, etc.
-	Priority           string   `json:"priority"`           // P0, P1, P2, P3
-	DiscoveryType      string   `json:"discovery_type"`     // blocker, related, background (vc-151)
+	Type               string   `json:"type"`                          // bug, task, enhancement, etc.
+	Priority           string   `json:"priority"`                      // P0, P1, P2, P3
+	DiscoveryType      string   `json:"discovery_type"`                // blocker, related, background (vc-151)
 	AcceptanceCriteria string   `json:"acceptance_criteria,omitempty"` // vc-4vot: Required for meta-issues
-	Labels             []string `json:"labels,omitempty"`   // vc-4vot: AI-set labels (e.g., "meta-issue")
+	Labels             []string `json:"labels,omitempty"`              // vc-4vot: AI-set labels (e.g., "meta-issue")
 }
 
 // No heuristic pattern matching - we'll rely on AI to set labels
@@ -242,23 +242,23 @@ func (s *Supervisor) verifyMetaIssueStillNeeded(ctx context.Context, parentIssue
 // Recursion Prevention (vc-4vot, vc-o87x):
 // This function implements multiple layers of protection against infinite meta-issue recursion:
 //
-// 1. State Verification (vc-o87x): Before creating a meta-issue, re-fetch the parent issue from
-//    the database to verify the problem still exists. This prevents creating obsolete meta-issues
-//    when the parent was updated between analysis time and creation time.
-//    Example: AI sees "missing acceptance criteria" at T0, but criteria were added at T1.
+//  1. State Verification (vc-o87x): Before creating a meta-issue, re-fetch the parent issue from
+//     the database to verify the problem still exists. This prevents creating obsolete meta-issues
+//     when the parent was updated between analysis time and creation time.
+//     Example: AI sees "missing acceptance criteria" at T0, but criteria were added at T1.
 //
-// 2. Circular Meta-Issue Detection (vc-4vot): Prevent meta-issues about meta-issues.
-//    If parent has "meta-issue" label AND child has "meta-issue" label, skip creation.
-//    Example: vc-hpcl → vc-9yhu (meta) → vc-qo2u (meta) is blocked at vc-qo2u.
+//  2. Circular Meta-Issue Detection (vc-4vot): Prevent meta-issues about meta-issues.
+//     If parent has "meta-issue" label AND child has "meta-issue" label, skip creation.
+//     Example: vc-hpcl → vc-9yhu (meta) → vc-qo2u (meta) is blocked at vc-qo2u.
 //
-// 3. Meta-Issue Acceptance Criteria (vc-4vot): Meta-issues MUST have acceptance criteria.
-//    Without criteria, meta-issues themselves trigger more meta-issues, creating infinite recursion.
+//  3. Meta-Issue Acceptance Criteria (vc-4vot): Meta-issues MUST have acceptance criteria.
+//     Without criteria, meta-issues themselves trigger more meta-issues, creating infinite recursion.
 //
-// 4. Blocker Depth Limit (vc-4vot): Maximum 2 levels of discovered:blocker chains.
-//    This prevents blocker → blocker → blocker → ... chains that clog the tracker.
+//  4. Blocker Depth Limit (vc-4vot): Maximum 2 levels of discovered:blocker chains.
+//     This prevents blocker → blocker → blocker → ... chains that clog the tracker.
 //
-// 5. Circuit Breaker (vc-4vot): If >5 blockers discovered at once, create a single
-//    escalation issue instead. This catches systemic problems and runaway recursion.
+//  5. Circuit Breaker (vc-4vot): If >5 blockers discovered at once, create a single
+//     escalation issue instead. This catches systemic problems and runaway recursion.
 func (s *Supervisor) CreateDiscoveredIssues(ctx context.Context, parentIssue *types.Issue, discovered []DiscoveredIssue) ([]string, error) {
 	var createdIDs []string
 	var skipped []string
@@ -277,11 +277,11 @@ func (s *Supervisor) CreateDiscoveredIssues(ctx context.Context, parentIssue *ty
 
 		// Create a single escalation issue instead of creating all blockers
 		escalationIssue := &types.Issue{
-			Title:       fmt.Sprintf("Excessive blocker discovery in %s - needs human review", parentIssue.ID),
-			Description: fmt.Sprintf("The AI analysis discovered %d blocking issues for %s, which suggests a systemic problem or infinite recursion.\n\nParent Issue: %s\nParent Title: %s\n\nPlease review the parent issue and address the root cause.\n\n_Discovered during execution of %s_", blockerCount, parentIssue.ID, parentIssue.ID, parentIssue.Title, parentIssue.ID),
-			IssueType:   types.TypeTask,
-			Status:      types.StatusOpen,
-			Priority:    0, // P0 - critical
+			Title:              fmt.Sprintf("Excessive blocker discovery in %s - needs human review", parentIssue.ID),
+			Description:        fmt.Sprintf("The AI analysis discovered %d blocking issues for %s, which suggests a systemic problem or infinite recursion.\n\nParent Issue: %s\nParent Title: %s\n\nPlease review the parent issue and address the root cause.\n\n_Discovered during execution of %s_", blockerCount, parentIssue.ID, parentIssue.ID, parentIssue.Title, parentIssue.ID),
+			IssueType:          types.TypeTask,
+			Status:             types.StatusOpen,
+			Priority:           0, // P0 - critical
 			AcceptanceCriteria: "1. Review parent issue and discovered blockers list\n2. Identify root cause of excessive blocker discovery\n3. Resolve underlying issue or reconfigure AI analysis\n4. Ensure parent issue has clear acceptance criteria",
 		}
 
@@ -391,7 +391,7 @@ func (s *Supervisor) CreateDiscoveredIssues(ctx context.Context, parentIssue *ty
 			Description:        disc.Description + fmt.Sprintf("\n\n_Discovered during execution of %s_", parentIssue.ID),
 			IssueType:          issueType,
 			Status:             types.StatusOpen,
-			Priority:           priority, // Use calculated priority (vc-152)
+			Priority:           priority,           // Use calculated priority (vc-152)
 			AcceptanceCriteria: acceptanceCriteria, // vc-4vot: Include acceptance criteria from AI
 		}
 

--- a/internal/ai/translation_test.go
+++ b/internal/ai/translation_test.go
@@ -31,11 +31,11 @@ func TestMetaIssueRecursionPrevention(t *testing.T) {
 	t.Run("circular_meta_issue_detection", func(t *testing.T) {
 		// Create parent meta-issue (represents vc-9yhu: adds criteria to vc-hpcl)
 		parentIssue := &types.Issue{
-			Title:       "Add acceptance criteria to vc-hpcl",
-			Description: "vc-hpcl needs acceptance criteria",
-			IssueType:   types.TypeTask,
-			Status:      types.StatusOpen,
-			Priority:    1,
+			Title:              "Add acceptance criteria to vc-hpcl",
+			Description:        "vc-hpcl needs acceptance criteria",
+			IssueType:          types.TypeTask,
+			Status:             types.StatusOpen,
+			Priority:           1,
 			AcceptanceCriteria: "1. Add criteria to vc-hpcl\n2. Ensure criteria are clear",
 		}
 		if err := store.CreateIssue(ctx, parentIssue, "test"); err != nil {

--- a/internal/ai/utils.go
+++ b/internal/ai/utils.go
@@ -40,12 +40,12 @@ func (s *Supervisor) recordAIUsage(ctx context.Context, issueID, activity string
 		// Record operation-level details for quota monitoring (vc-7e21)
 		// We create a map instead of importing cost.QuotaOperation to avoid circular dependency
 		op := map[string]interface{}{
-			"issue_id":        issueID,
-			"operation_type":  activity,
-			"model":           s.model,
-			"input_tokens":    inputTokens,
-			"output_tokens":   outputTokens,
-			"duration_ms":     duration.Milliseconds(),
+			"issue_id":       issueID,
+			"operation_type": activity,
+			"model":          s.model,
+			"input_tokens":   inputTokens,
+			"output_tokens":  outputTokens,
+			"duration_ms":    duration.Milliseconds(),
 		}
 		if err := s.costTracker.RecordOperation(ctx, op); err != nil {
 			// Log warning but don't fail (operation tracking is best-effort)
@@ -271,8 +271,8 @@ func truncateString(s string, maxLen int) string {
 	}
 
 	// Calculate chunk sizes proportionally
-	firstChunk := maxLen / 8     // ~12.5% for context
-	middleChunk := maxLen / 4    // ~25% for work sample
+	firstChunk := maxLen / 8                             // ~12.5% for context
+	middleChunk := maxLen / 4                            // ~25% for work sample
 	lastChunk := maxLen - firstChunk - middleChunk - 100 // Rest for results (minus markers)
 
 	// Extract chunks with bounds checking


### PR DESCRIPTION
## Summary

Add support for custom API base URLs, enabling VC to work with OpenAI-compatible API wrappers like `claude-code-openai-wrapper`.

**Changes:**
- Add `BaseURL` field to `ai.Config` struct
- Check `VC_API_BASE` environment variable if `BaseURL` not provided
- Use `option.WithBaseURL()` when creating Anthropic client
- Fix missing `APIKey` in circuit breaker tests (pre-existing bug)
- Run `go fmt` on internal/ai package

**Usage:**
```bash
export VC_API_BASE=http://localhost:8000
vc list  # Now uses custom endpoint
```

## Test Plan
- [x] Unit tests for BaseURL configuration
- [x] Integration test with API wrapper
- [x] All existing tests pass (fixed pre-existing failures)
- [x] `go fmt` and `golangci-lint` clean

Authored by: Aaron Lippold<lippold@gmail.com>