### PR TITLE
feat(cli): implement mission plan refinement

### DIFF
--- a/cmd/vc/plan.go
+++ b/cmd/vc/plan.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -12,6 +14,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/vc/internal/ai"
+	"github.com/steveyegge/vc/internal/iterative"
+	"github.com/steveyegge/vc/internal/storage"
 	"github.com/steveyegge/vc/internal/types"
 )
 
@@ -261,18 +265,137 @@ var planListCmd = &cobra.Command{
 
 var planRefineCmd = &cobra.Command{
 	Use:   "refine <mission-id>",
-	Short: "Refine a plan with AI feedback",
+	Short: "Refine a plan with AI-guided convergence",
 	Long: `Iteratively refine a mission plan using AI-guided convergence.
 This runs multiple refinement iterations until the plan stabilizes.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		missionID := args[0]
+		ctx := context.Background()
 
-		// TODO: Implement plan refinement (Epic 2: vc-3yi1)
+		plan, iteration, err := store.GetPlan(ctx, missionID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to get plan: %v\n", err)
+			os.Exit(1)
+		}
+		if plan == nil {
+			fmt.Fprintf(os.Stderr, "Error: no plan found for mission %s\n", missionID)
+			os.Exit(1)
+		}
+
+		supervisor, err := ai.NewSupervisor(&ai.Config{
+			Model: ai.GetDefaultModel(),
+			Store: store,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to initialize AI supervisor: %v\n", err)
+			os.Exit(1)
+		}
+
+		refiner := ai.NewPlanRefiner(supervisor, buildPlanningContextForStoredPlan(plan))
+		config := iterative.RefinementConfig{
+			MinIterations: 3,
+			MaxIterations: 5,
+			SkipSimple:    false,
+		}
+
 		yellow := color.New(color.FgYellow).SprintFunc()
-		fmt.Printf("\n%s 'vc plan refine' not yet implemented (see vc-3yi1)\n", yellow("⚠"))
-		fmt.Printf("Mission: %s\n\n", missionID)
+		cyan := color.New(color.FgCyan).SprintFunc()
+		green := color.New(color.FgGreen).SprintFunc()
+		gray := color.New(color.FgHiBlack).SprintFunc()
+
+		fmt.Printf("\n%s Refining mission plan...\n", cyan("🤖"))
+
+		refinedPlan, result, err := refineMissionPlan(
+			ctx,
+			plan,
+			refiner,
+			config,
+			fmt.Sprintf("Refining draft for mission %s (stored iteration %d)", missionID, iteration),
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to refine plan: %v\n", err)
+			os.Exit(1)
+		}
+
+		newIteration, err := store.StorePlan(ctx, refinedPlan, iteration)
+		if err != nil {
+			if errors.Is(err, storage.ErrStaleIteration) {
+				fmt.Fprintf(os.Stderr, "Error: plan changed while refining; rerun 'vc plan show %s' and retry\n", missionID)
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "Error: failed to store refined plan: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("\n%s Plan refined successfully!\n", green("✓"))
+		fmt.Printf("%s Mission: %s\n", gray("├─"), missionID)
+		fmt.Printf("%s Stored iteration: %d → %d\n", gray("├─"), iteration, newIteration)
+		fmt.Printf("%s Refinement passes: %d\n", gray("├─"), result.Iterations)
+		fmt.Printf("%s Converged: %t\n", gray("├─"), result.Converged)
+		fmt.Printf("%s Confidence: %.0f%%\n", gray("├─"), refinedPlan.Confidence*100)
+		fmt.Printf("%s Duration: %s\n", gray("└─"), result.ElapsedTime.Round(time.Millisecond))
+
+		if !result.Converged {
+			fmt.Printf("\n%s Reached max refinement iterations; stored the latest draft anyway.\n", yellow("⚠"))
+		}
+
+		fmt.Printf("\n%s Next steps:\n", cyan("📋"))
+		fmt.Printf("  • Review: %s\n", cyan(fmt.Sprintf("vc plan show %s", missionID)))
+		fmt.Printf("  • Validate: %s\n", gray(fmt.Sprintf("vc plan validate %s", missionID)))
+		fmt.Printf("  • Approve: %s\n\n", gray(fmt.Sprintf("vc plan approve %s", missionID)))
 	},
+}
+
+func buildPlanningContextForStoredPlan(plan *types.MissionPlan) *types.PlanningContext {
+	return &types.PlanningContext{
+		Mission: &types.Mission{
+			Issue: types.Issue{
+				ID:          plan.MissionID,
+				Title:       plan.MissionID,
+				Description: plan.Strategy,
+				IssueType:   types.TypeEpic,
+				Status:      types.StatusOpen,
+				Priority:    1,
+				CreatedAt:   plan.GeneratedAt,
+				UpdatedAt:   plan.GeneratedAt,
+			},
+			Goal:    plan.Strategy,
+			Context: plan.Strategy,
+		},
+	}
+}
+
+func refineMissionPlan(
+	ctx context.Context,
+	currentPlan *types.MissionPlan,
+	refiner iterative.Refiner,
+	config iterative.RefinementConfig,
+	artifactContext string,
+) (*types.MissionPlan, *iterative.ConvergenceResult, error) {
+	planJSON, err := json.Marshal(currentPlan)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to serialize current plan: %w", err)
+	}
+
+	result, err := iterative.Converge(ctx, &iterative.Artifact{
+		Type:    "mission_plan",
+		Content: string(planJSON),
+		Context: artifactContext,
+	}, refiner, config, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var refinedPlan types.MissionPlan
+	if err := json.Unmarshal([]byte(result.FinalArtifact.Content), &refinedPlan); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse refined plan: %w", err)
+	}
+	if err := refinedPlan.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("refined plan failed validation: %w", err)
+	}
+
+	return &refinedPlan, result, nil
 }
 
 var planValidateCmd = &cobra.Command{

--- a/cmd/vc/plan_test.go
+++ b/cmd/vc/plan_test.go
@@ -2,14 +2,62 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/steveyegge/vc/internal/iterative"
 	"github.com/steveyegge/vc/internal/storage/beads"
 	"github.com/steveyegge/vc/internal/types"
 )
+
+type testMissionPlanRefiner struct {
+	refineFunc           func(plan *types.MissionPlan) (*types.MissionPlan, error)
+	checkConvergenceFunc func(call int, current, previous *types.MissionPlan) (*iterative.ConvergenceDecision, error)
+	refineCalls          int
+}
+
+func (r *testMissionPlanRefiner) Refine(ctx context.Context, artifact *iterative.Artifact) (*iterative.Artifact, error) {
+	r.refineCalls++
+
+	var plan types.MissionPlan
+	if err := json.Unmarshal([]byte(artifact.Content), &plan); err != nil {
+		return nil, err
+	}
+
+	nextPlan, err := r.refineFunc(&plan)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := json.Marshal(nextPlan)
+	if err != nil {
+		return nil, err
+	}
+
+	return &iterative.Artifact{
+		Type:    artifact.Type,
+		Content: string(content),
+		Context: artifact.Context,
+	}, nil
+}
+
+func (r *testMissionPlanRefiner) CheckConvergence(ctx context.Context, current, previous *iterative.Artifact) (*iterative.ConvergenceDecision, error) {
+	var currentPlan types.MissionPlan
+	if err := json.Unmarshal([]byte(current.Content), &currentPlan); err != nil {
+		return nil, err
+	}
+
+	var previousPlan types.MissionPlan
+	if err := json.Unmarshal([]byte(previous.Content), &previousPlan); err != nil {
+		return nil, err
+	}
+
+	return r.checkConvergenceFunc(r.refineCalls, &currentPlan, &previousPlan)
+}
 
 // TestPlanShowCommand tests that the plan show command can display a plan (vc-25zn)
 func TestPlanShowCommand(t *testing.T) {
@@ -229,5 +277,138 @@ func TestGetStatusColor(t *testing.T) {
 				t.Error("Expected non-empty colored string")
 			}
 		})
+	}
+}
+
+func TestRefineMissionPlan(t *testing.T) {
+	initialPlan := &types.MissionPlan{
+		MissionID: "plan-1234",
+		Phases: []types.PlannedPhase{
+			{
+				PhaseNumber:     1,
+				Title:           "Draft phase",
+				Description:     "Initial draft",
+				Strategy:        "Start simple",
+				Tasks:           []string{"Add first task"},
+				EstimatedEffort: "1 day",
+			},
+		},
+		Strategy:        "Initial strategy",
+		Risks:           []string{"unknowns"},
+		EstimatedEffort: "2 days",
+		Confidence:      0.55,
+		GeneratedAt:     time.Now(),
+		GeneratedBy:     "test",
+		Status:          "draft",
+	}
+
+	refiner := &testMissionPlanRefiner{
+		refineFunc: func(plan *types.MissionPlan) (*types.MissionPlan, error) {
+			next := *plan
+			next.Confidence += 0.1
+			next.Status = "refining"
+			next.Phases = append([]types.PlannedPhase(nil), plan.Phases...)
+			next.Phases[0].Tasks = append([]string{}, plan.Phases[0].Tasks...)
+			next.Phases[0].Tasks = append(next.Phases[0].Tasks, fmt.Sprintf("Refinement pass %d", len(plan.Phases[0].Tasks)))
+			return &next, nil
+		},
+		checkConvergenceFunc: func(call int, current, previous *types.MissionPlan) (*iterative.ConvergenceDecision, error) {
+			return &iterative.ConvergenceDecision{
+				Converged:  call >= 2,
+				Confidence: 0.9,
+				Reasoning:  "test convergence",
+				Strategy:   "test",
+			}, nil
+		},
+	}
+
+	refinedPlan, result, err := refineMissionPlan(
+		context.Background(),
+		initialPlan,
+		refiner,
+		iterative.RefinementConfig{
+			MinIterations: 1,
+			MaxIterations: 3,
+		},
+		"test refinement",
+	)
+	if err != nil {
+		t.Fatalf("refineMissionPlan failed: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected convergence result")
+	}
+	if !result.Converged {
+		t.Error("Expected converged=true")
+	}
+	if result.Iterations != 2 {
+		t.Errorf("Expected 2 refinement passes, got %d", result.Iterations)
+	}
+	if refinedPlan.Status != "refining" {
+		t.Errorf("Expected status refining, got %s", refinedPlan.Status)
+	}
+	if refinedPlan.Confidence <= initialPlan.Confidence {
+		t.Errorf("Expected confidence to improve, got %.2f", refinedPlan.Confidence)
+	}
+	if got := len(refinedPlan.Phases[0].Tasks); got != 3 {
+		t.Errorf("Expected 3 tasks after refinement, got %d", got)
+	}
+}
+
+func TestRefineMissionPlanRejectsInvalidOutput(t *testing.T) {
+	initialPlan := &types.MissionPlan{
+		MissionID: "plan-bad",
+		Phases: []types.PlannedPhase{
+			{
+				PhaseNumber:     1,
+				Title:           "Draft phase",
+				Description:     "Initial draft",
+				Strategy:        "Start simple",
+				Tasks:           []string{"Add first task"},
+				EstimatedEffort: "1 day",
+			},
+		},
+		Strategy:        "Initial strategy",
+		Risks:           []string{"unknowns"},
+		EstimatedEffort: "2 days",
+		Confidence:      0.55,
+		GeneratedAt:     time.Now(),
+		GeneratedBy:     "test",
+		Status:          "draft",
+	}
+
+	refiner := &testMissionPlanRefiner{
+		refineFunc: func(plan *types.MissionPlan) (*types.MissionPlan, error) {
+			return &types.MissionPlan{
+				MissionID: plan.MissionID,
+				Status:    "refining",
+			}, nil
+		},
+		checkConvergenceFunc: func(call int, current, previous *types.MissionPlan) (*iterative.ConvergenceDecision, error) {
+			return &iterative.ConvergenceDecision{
+				Converged:  true,
+				Confidence: 1.0,
+				Reasoning:  "invalid output for test",
+				Strategy:   "test",
+			}, nil
+		},
+	}
+
+	_, _, err := refineMissionPlan(
+		context.Background(),
+		initialPlan,
+		refiner,
+		iterative.RefinementConfig{
+			MinIterations: 1,
+			MaxIterations: 1,
+		},
+		"invalid refinement",
+	)
+	if err == nil {
+		t.Fatal("Expected validation error from invalid refined plan")
+	}
+	if !strings.Contains(err.Error(), "refined plan failed validation") {
+		t.Fatalf("Expected validation error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- implement `vc plan refine` using the existing plan refiner and iterative convergence loop
- persist refined plans with optimistic locking and clearer CLI output
- add unit coverage for successful refinement and invalid refined output

## Testing
- go test -run 'TestPlanShowCommand|TestPlanListCommand|TestGenerateShortUUID|TestGetStatusColor|TestRefineMissionPlan|TestRefineMissionPlanRejectsInvalidOutput' ./cmd/vc