### PR TITLE
fix(codereview): reuse prior review summaries

### DIFF
--- a/internal/codereview/sweep.go
+++ b/internal/codereview/sweep.go
@@ -138,8 +138,7 @@ func (s *Sweeper) GetDiffMetrics(ctx context.Context) (*types.ReviewMetricsResul
 	totalLOC := getTotalLOC(ctx)
 
 	// Get last review summary (if available)
-	lastReviewSummary := ""
-	// TODO: Retrieve summary from last review issue when implemented
+	lastReviewSummary := s.getLastReviewSummary(ctx, checkpoint)
 
 	return &types.ReviewMetricsResult{
 		Metrics: &types.ReviewDecisionRequest{
@@ -153,6 +152,54 @@ func (s *Sweeper) GetDiffMetrics(ctx context.Context) (*types.ReviewMetricsResul
 		},
 		CommitSHA: currentCommitSHA, // Return actual SHA used for diff calculation
 	}, nil
+}
+
+func (s *Sweeper) getLastReviewSummary(ctx context.Context, checkpoint *types.ReviewCheckpoint) string {
+	if checkpoint == nil || checkpoint.ReviewIssueID == "" {
+		return ""
+	}
+
+	issue, err := s.store.GetIssue(ctx, checkpoint.ReviewIssueID)
+	if err != nil || issue == nil {
+		return ""
+	}
+
+	title := strings.TrimSpace(issue.Title)
+	reasoning := extractReviewReasoning(issue.Description)
+
+	if title == "" {
+		return reasoning
+	}
+	if reasoning == "" {
+		return title
+	}
+
+	return title + " - " + reasoning
+}
+
+func extractReviewReasoning(description string) string {
+	const marker = "**AI Reasoning:**"
+
+	idx := strings.Index(description, marker)
+	if idx == -1 {
+		return ""
+	}
+
+	lines := strings.Split(description[idx+len(marker):], "\n")
+	parts := make([]string, 0, len(lines))
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "**") {
+			break
+		}
+		parts = append(parts, line)
+	}
+
+	return strings.Join(parts, " ")
 }
 
 // parseDiffStats parses git diff --shortstat output

--- a/internal/codereview/sweep_test.go
+++ b/internal/codereview/sweep_test.go
@@ -2,8 +2,15 @@ package codereview
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/vc/internal/storage/beads"
+	"github.com/steveyegge/vc/internal/types"
 )
 
 // TestGetTotalLOCCaching tests that getTotalLOC() uses cache correctly
@@ -143,4 +150,143 @@ func TestGetTotalLOCContextCancellation(t *testing.T) {
 	}
 
 	t.Logf("Canceled call duration: %v", duration)
+}
+
+func TestGetDiffMetricsIncludesLastReviewSummary(t *testing.T) {
+	ctx := context.Background()
+	repoDir := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	initTestRepo(t, repoDir)
+	baseSHA := commitFile(t, repoDir, "main.go", "package main\n\nfunc main() {}\n", "initial commit")
+
+	store, err := beads.NewVCStorage(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create VC storage: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	reviewIssue := &types.Issue{
+		Title: "Code Review Sweep: quick",
+		Description: `Perform quick code review sweep based on accumulated activity.
+
+**AI Reasoning:**
+Focus on executor concurrency and error handling.
+
+**Scope:** quick`,
+		Status:             types.StatusOpen,
+		Priority:           1,
+		IssueType:          types.TypeTask,
+		AcceptanceCriteria: "Review the target files",
+	}
+	if err := store.CreateIssue(ctx, reviewIssue, "test"); err != nil {
+		t.Fatalf("Failed to create review issue: %v", err)
+	}
+
+	checkpoint := &types.ReviewCheckpoint{
+		CommitSHA:   baseSHA,
+		Timestamp:   time.Now().Add(-48 * time.Hour).UTC(),
+		ReviewScope: "quick",
+	}
+	if err := store.SaveReviewCheckpoint(ctx, checkpoint, reviewIssue.ID); err != nil {
+		t.Fatalf("Failed to save review checkpoint: %v", err)
+	}
+
+	commitFile(t, repoDir, "main.go", "package main\n\nfunc main() {\n\tprintln(\"hi\")\n}\n", "add change")
+
+	resetLOCCache()
+	t.Chdir(repoDir)
+
+	result, err := NewSweeper(store).GetDiffMetrics(ctx)
+	if err != nil {
+		t.Fatalf("GetDiffMetrics returned error: %v", err)
+	}
+
+	want := "Code Review Sweep: quick - Focus on executor concurrency and error handling."
+	if result.Metrics.LastReviewSummary != want {
+		t.Fatalf("Expected LastReviewSummary %q, got %q", want, result.Metrics.LastReviewSummary)
+	}
+}
+
+func TestGetDiffMetricsLeavesLastReviewSummaryEmptyWithoutReviewIssue(t *testing.T) {
+	ctx := context.Background()
+	repoDir := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	initTestRepo(t, repoDir)
+	baseSHA := commitFile(t, repoDir, "main.go", "package main\n\nfunc main() {}\n", "initial commit")
+
+	store, err := beads.NewVCStorage(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create VC storage: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	checkpoint := &types.ReviewCheckpoint{
+		CommitSHA:   baseSHA,
+		Timestamp:   time.Now().Add(-24 * time.Hour).UTC(),
+		ReviewScope: "quick",
+	}
+	if err := store.SaveReviewCheckpoint(ctx, checkpoint, ""); err != nil {
+		t.Fatalf("Failed to save review checkpoint: %v", err)
+	}
+
+	commitFile(t, repoDir, "main.go", "package main\n\nfunc main() {\n\tprintln(\"bye\")\n}\n", "add change")
+
+	resetLOCCache()
+	t.Chdir(repoDir)
+
+	result, err := NewSweeper(store).GetDiffMetrics(ctx)
+	if err != nil {
+		t.Fatalf("GetDiffMetrics returned error: %v", err)
+	}
+	if result.Metrics.LastReviewSummary != "" {
+		t.Fatalf("Expected empty LastReviewSummary, got %q", result.Metrics.LastReviewSummary)
+	}
+}
+
+func resetLOCCache() {
+	cachedLOCMutex.Lock()
+	cachedLOC = 0
+	cachedLOCTime = time.Time{}
+	cachedLOCMutex.Unlock()
+}
+
+func initTestRepo(t *testing.T, repoDir string) {
+	t.Helper()
+
+	runGit(t, repoDir, "init", "--initial-branch=main")
+	runGit(t, repoDir, "config", "user.name", "Test User")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	hooksDir := filepath.Join(repoDir, ".git", "empty-hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatalf("Failed to create empty hooks dir: %v", err)
+	}
+	runGit(t, repoDir, "config", "core.hooksPath", hooksDir)
+	runGit(t, repoDir, "checkout", "-b", "feature/test-review-summary")
+}
+
+func commitFile(t *testing.T, repoDir, path, content, message string) string {
+	t.Helper()
+
+	fullPath := filepath.Join(repoDir, path)
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write %s: %v", path, err)
+	}
+	runGit(t, repoDir, "add", path)
+	runGit(t, repoDir, "commit", "-m", message)
+
+	return strings.TrimSpace(runGit(t, repoDir, "rev-parse", "HEAD"))
+}
+
+func runGit(t *testing.T, repoDir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, output)
+	}
+	return string(output)
 }

--- a/internal/storage/beads/methods.go
+++ b/internal/storage/beads/methods.go
@@ -507,10 +507,10 @@ func (s *VCStorage) UpdateMission(ctx context.Context, id string, updates map[st
 			Severity:  events.SeverityInfo,
 			Message:   fmt.Sprintf("Mission metadata updated: %s (fields: %v)", id, updatedFields),
 			Data: map[string]interface{}{
-				"mission_id":      eventData.MissionID,
-				"updated_fields":  eventData.UpdatedFields,
-				"changes":         changesMap,
-				"actor":           eventData.Actor,
+				"mission_id":     eventData.MissionID,
+				"updated_fields": eventData.UpdatedFields,
+				"changes":        changesMap,
+				"actor":          eventData.Actor,
 			},
 		}
 
@@ -1781,7 +1781,7 @@ func (s *VCStorage) GetMissionForTask(ctx context.Context, taskID string) (*type
 	var missionID, issueType, subtype, sandboxPath, branchName string
 	err := s.db.QueryRowContext(ctx, query,
 		taskID, types.DepParentChild, // Base case parameters
-		types.DepParentChild, // Recursive case parameter
+		types.DepParentChild,                 // Recursive case parameter
 		types.TypeEpic, types.SubtypeMission, // WHERE clause parameters
 	).Scan(&missionID, &issueType, &subtype, &sandboxPath, &branchName)
 
@@ -1930,18 +1930,22 @@ func (s *VCStorage) VacuumDatabase(ctx context.Context) error {
 // GetLastReviewCheckpoint retrieves the most recent code review checkpoint
 func (s *VCStorage) GetLastReviewCheckpoint(ctx context.Context) (*types.ReviewCheckpoint, error) {
 	var checkpoint types.ReviewCheckpoint
+	var reviewIssueID sql.NullString
 	err := s.db.QueryRowContext(ctx, `
-		SELECT commit_sha, timestamp, review_scope
+		SELECT commit_sha, timestamp, review_scope, review_issue_id
 		FROM vc_review_checkpoints
 		ORDER BY timestamp DESC
 		LIMIT 1
-	`).Scan(&checkpoint.CommitSHA, &checkpoint.Timestamp, &checkpoint.ReviewScope)
+	`).Scan(&checkpoint.CommitSHA, &checkpoint.Timestamp, &checkpoint.ReviewScope, &reviewIssueID)
 
 	if err == sql.ErrNoRows {
 		return nil, nil // No checkpoint yet
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to query last review checkpoint: %w", err)
+	}
+	if reviewIssueID.Valid {
+		checkpoint.ReviewIssueID = reviewIssueID.String
 	}
 
 	return &checkpoint, nil

--- a/internal/storage/beads/methods_test.go
+++ b/internal/storage/beads/methods_test.go
@@ -447,6 +447,51 @@ func TestHealthMetricsTimeFiltering(t *testing.T) {
 	}
 }
 
+func TestGetLastReviewCheckpointIncludesReviewIssueID(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	store, err := NewVCStorage(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create VC storage: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	reviewIssue := &types.Issue{
+		Title:              "Code Review Sweep: quick",
+		Description:        "Existing review findings",
+		Status:             types.StatusOpen,
+		Priority:           1,
+		IssueType:          types.TypeTask,
+		AcceptanceCriteria: "Capture review findings",
+	}
+	if err := store.CreateIssue(ctx, reviewIssue, "test"); err != nil {
+		t.Fatalf("Failed to create review issue: %v", err)
+	}
+
+	checkpoint := &types.ReviewCheckpoint{
+		CommitSHA:   "abc1234",
+		Timestamp:   time.Now().Add(-24 * time.Hour).UTC(),
+		ReviewScope: "quick",
+	}
+	if err := store.SaveReviewCheckpoint(ctx, checkpoint, reviewIssue.ID); err != nil {
+		t.Fatalf("Failed to save review checkpoint: %v", err)
+	}
+
+	lastCheckpoint, err := store.GetLastReviewCheckpoint(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get last review checkpoint: %v", err)
+	}
+	if lastCheckpoint == nil {
+		t.Fatal("Expected checkpoint, got nil")
+	}
+	if lastCheckpoint.ReviewIssueID != reviewIssue.ID {
+		t.Fatalf("Expected review_issue_id %q, got %q", reviewIssue.ID, lastCheckpoint.ReviewIssueID)
+	}
+}
+
 // TestHealthMetricsRetention verifies that the 30-day retention policy works correctly
 // Tests automatic cleanup and manual CleanupOldMetrics (vc-2px0)
 func TestHealthMetricsRetention(t *testing.T) {

--- a/internal/types/code_review.go
+++ b/internal/types/code_review.go
@@ -5,9 +5,10 @@ import "time"
 // ReviewCheckpoint tracks when the last code review sweep occurred
 // Used to calculate git diff metrics since last review
 type ReviewCheckpoint struct {
-	CommitSHA   string    // Last reviewed commit
-	Timestamp   time.Time // When the review was performed
-	ReviewScope string    // "quick" | "thorough" | "targeted:path/to/dir"
+	CommitSHA     string    // Last reviewed commit
+	Timestamp     time.Time // When the review was performed
+	ReviewScope   string    // "quick" | "thorough" | "targeted:path/to/dir"
+	ReviewIssueID string    // Review issue created for the checkpoint, if any
 }
 
 // ReviewDecisionRequest contains git metrics for AI to decide if review is needed
@@ -35,18 +36,18 @@ type ReviewMetricsResult struct {
 
 // ReviewDecision represents AI decision about triggering a code review sweep
 type ReviewDecision struct {
-	ShouldReview    bool     `json:"should_review"`    // Should we trigger a code review now?
-	Reasoning       string   `json:"reasoning"`        // Detailed reasoning for the decision
-	Scope           string   `json:"scope"`            // "quick" | "thorough" | "targeted"
-	TargetAreas     []string `json:"target_areas"`     // Specific directories/packages to review (null = broad)
-	EstimatedFiles  int      `json:"estimated_files"`  // Estimated number of files to review (5-15)
-	EstimatedCost   string   `json:"estimated_cost"`   // Estimated cost (e.g., "$1-5")
+	ShouldReview   bool     `json:"should_review"`   // Should we trigger a code review now?
+	Reasoning      string   `json:"reasoning"`       // Detailed reasoning for the decision
+	Scope          string   `json:"scope"`           // "quick" | "thorough" | "targeted"
+	TargetAreas    []string `json:"target_areas"`    // Specific directories/packages to review (null = broad)
+	EstimatedFiles int      `json:"estimated_files"` // Estimated number of files to review (5-15)
+	EstimatedCost  string   `json:"estimated_cost"`  // Estimated cost (e.g., "$1-5")
 }
 
 // FileReviewResult represents the AI review of a single file
 type FileReviewResult struct {
-	FilePath string              `json:"file_path"` // Path to reviewed file
-	Issues   []FileReviewIssue   `json:"issues"`    // Issues found (0-3 per file)
+	FilePath string            `json:"file_path"` // Path to reviewed file
+	Issues   []FileReviewIssue `json:"issues"`    // Issues found (0-3 per file)
 }
 
 // FileReviewIssue represents a single issue found during file review


### PR DESCRIPTION
## Summary
- thread `review_issue_id` through `GetLastReviewCheckpoint`
- reuse the previous code-review issues `**AI Reasoning:**` section as `LastReviewSummary`
- add regression tests for checkpoint round-tripping and populated vs empty summary paths

## Testing
- go test ./internal/codereview ./internal/storage/beads
- go test ./internal/ai ./internal/executor -run TestDefinitelyDoesNotExist
